### PR TITLE
Edit mentor form - input project name instead link

### DIFF
--- a/kwoc/app.py
+++ b/kwoc/app.py
@@ -81,8 +81,8 @@ def testimonials():
 
 @app.route("/mentor_form")
 def mentor_form():
-    return "Registrations have now been closed. See you next year !"
-    # return render_template('mentor_form.html')
+    #return "Registrations have now been closed. See you next year !"
+    return render_template('mentor_form.html')
 
 
 @app.route("/student_form")

--- a/templates/mentor_form.html
+++ b/templates/mentor_form.html
@@ -261,17 +261,21 @@ form {
       <input type="email" name="email" required="required" placeholder="Email Address" autocomplete="off"></input>
     </div>
     <div class="form-item">
+      <label for="handle-name"></label>
+      <input type="text" name="handle-name" required="required" placeholder="Github handle" autocomplete="off"></input>
+    </div>
+    <div class="form-item">
       <label for="project"></label>
-      <input type="text" name="project" required="required" placeholder="Project Name" autocomplete="off"></input>
+      <input type="text" name="project" required="required" placeholder="Project Name on github" autocomplete="off"></input>
     </div>
     <div class="form-item">
       <label for="desc"></label>
       <input type="text" name="desc" required="required" placeholder="Project Description" autocomplete="off"></input>
     </div>
-    <div class="form-item">
+<!-- <div class="form-item">
       <label for="gitlink"></label>
-      <input type="text" name="gitlink" required="required" placeholder="Github Project Link" autocomplete="off"></input>
-    </div>
+      <input type="text" name="gitlink" required="required" placeholder="Github " autocomplete="off"></input>
+    </div>  -->
     <div class="form-item">
       <label for="communication"></label>
       <input type="text" name="communication" required="required" placeholder="Communication Channel Link (e.g. Google group, Facebook group, gitter)" autocomplete="off"></input>


### PR DESCRIPTION
Issue #10 . Now the mentor is asked to input the GitHub handle name and repository name instead of the link to project