### PR TITLE
Add Sorting To Stats Table

### DIFF
--- a/kwoc/app.py
+++ b/kwoc/app.py
@@ -93,8 +93,8 @@ def mentor_form():
 
 @app.route("/student_form")
 def student_form():
-    return "Registrations have now been closed. See you next year !"
-    # return render_template('student_form.html')
+    # return "Registrations have now been closed. See you next year !"
+    return render_template('student_form.html')
 
 
 @app.route("/projects")

--- a/templates/stats.html
+++ b/templates/stats.html
@@ -173,14 +173,14 @@
                 </div>
             </div>
 
-            <table class="table-fill">
+            <table class="table-fill" id="statTable">
             <thead>
             <tr style="cursor:pointer" >
-            <th class="text-center">Name</th>
-            <th class="text-center">Github Username</th>
-             <th class="text-center">PRs (Open/Closed)</th>
-              <th class="text-center">Commits</th>
-              <th class="text-center">Lines added/removed</th>
+            <th class="text-center" onclick="sortTable(0)">Name</th>
+            <th class="text-center" onclick="sortTable(1)">Github Username</th>
+             <th class="text-center" onclick="sortTable(2)">PRs (Closed/Open)</th>
+              <th class="text-center" onclick="sortTable(3)">Commits</th>
+              <th class="text-center" onclick="sortTable(4)">Lines added/removed</th>
             </tr>
             </thead>
             <tbody class="table-hover">
@@ -188,7 +188,7 @@
               <tr style="cursor:pointer" onclick="location.href='/stats/{{ user }}'">
               <td class="text-center" data-target="#myModal"> {{ userdata.name }} </td>
               <td class="text-center"> {{ user }} </td>
-              <td class="text-center">{{ userdata.pr_open }}/{{ userdata.pr_closed }}</td>
+              <td class="text-center">{{ userdata.pr_closed }}/{{ userdata.pr_open }}</td>
               <td class="text-center">{{ userdata.no_of_commits }}</td>
               <td class="text-center">+{{ userdata.lines_added }} -{{ userdata.lines_removed }}</td>
             </tr>
@@ -278,5 +278,74 @@
         <script type="text/javascript" src="/static/js/imagesloaded.pkgd.min.js"></script>
         <!-- setting -->
         <script type="text/javascript" src="/static/js/main.js"></script>
+        <!-- sorting -->
+        <script>
+            function sortTable(n) {
+              var table, rows, switching, i, x, y, shouldSwitch, dir, switchcount = 0;
+              table = document.getElementById("statTable");
+              switching = true;
+              // Set the sorting direction to ascending:
+              dir = "asc";
+              /* Make a loop that will continue until
+              no switching has been done: */
+              while (switching) {
+                // Start by saying: no switching is done:
+                switching = false;
+                rows = table.rows;
+                /* Loop through all table rows (except the
+                first, which contains table headers): */
+                for (i = 1; i < (rows.length - 1); i++) {
+                  // Start by saying there should be no switching:
+                  shouldSwitch = false;
+                  /* Get the two elements you want to compare,
+                  one from current row and one from the next: */
+                  x = rows[i].getElementsByTagName("TD")[n];
+                  y = rows[i + 1].getElementsByTagName("TD")[n];
+                  /* Check if the two rows should switch place,
+                  based on the direction, asc or desc: */
+                  if (dir === "asc") {
+                    if (n <= 1 && (x.innerHTML.toLowerCase() > y.innerHTML.toLowerCase())) {
+                      // If so, mark as a switch and break the loop:
+                      shouldSwitch = true;
+                      break;
+                    }
+
+                    else if (n > 1 && (parseInt(x.innerHTML) > parseInt(y.innerHTML))) {
+                      // If so, mark as a switch and break the loop:
+                      shouldSwitch = true;
+                      break;
+                    }
+                  } else if (dir === "desc") {
+                    if (n<=1 && (x.innerHTML.toLowerCase() < y.innerHTML.toLowerCase())) {
+                      // If so, mark as a switch and break the loop:
+                      shouldSwitch = true;
+                      break;
+                    }
+                    else if (n>1 && (parseInt(x.innerHTML) < parseInt(y.innerHTML))) {
+                      // If so, mark as a switch and break the loop:
+                      shouldSwitch = true;
+                      break;
+                    }
+                  }
+                }
+                if (shouldSwitch) {
+                  /* If a switch has been marked, make the switch
+                  and mark that a switch has been done: */
+                  rows[i].parentNode.insertBefore(rows[i + 1], rows[i]);
+                  switching = true;
+                  // Each time a switch is done, increase this count by 1:
+                  switchcount ++;
+                } else {
+                  /* If no switching has been done AND the direction is "asc",
+                  set the direction to "desc" and run the while loop again. */
+                  if (switchcount == 0 && dir == "asc") {
+                    dir = "desc";
+                    switching = true;
+                  }
+                }
+              }
+            }
+            sortTable(0);
+        </script>
     </body>
 </html>


### PR DESCRIPTION
Now the following methods of sorting can be used on the leaderboard in both ascending and descending order depending what is the current order:

- By name
- By handlename
- By closed PRs (I chose this as this would be a better measure than PRs open and since they are both in same row, it can be done for both)
- By Commits
- By Lines added (same reason for not chosing lines removed as closed PRs).

The method has been implemented with help from [W3Schools](https://www.w3schools.com/howto/howto_js_sort_table.asp).

fixes #5 