### PR TITLE
Add validation check for student name and email

### DIFF
--- a/kwoc/app.py
+++ b/kwoc/app.py
@@ -370,8 +370,12 @@ def reg():
         # print(colleges)
         
         temp_dict_val = dict_val
-        if temp_dict_val["email"] == None:
-            temp_dict_val["email"] = "Email ID"
+        if not temp_dict_val["email"]:
+            temp_dict_val["email"] = ""
+
+        if not temp_dict_val["name"]:
+            temp_dict_val["name"] = ""
+
         return render_template('student_form.html', data=temp_dict_val, colleges=colleges)
 
 @app.route("/token")


### PR DESCRIPTION
Currently, almost 49 entries in the student registration contain 'None' as the name of the student. This is because we are not performing a validation check and not using the property of a placeholder. This patch resolves this problem. Also, I'm unable to test this since the student registration button is redirecting me to the main server.