### PR TITLE
updated text on homepage

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -605,8 +605,14 @@
                     <h5 class="wow fadeInDown"></h5>
                     <a style="background-color: grey" class="btn highlight-button-home-white-border margin-four no-margin-bottom wow fadeInUp" href="{{ url_for('projects') }}" target="_blank">View Projects</a>
                     {% else %}
+                    <!-- Registrations are closed
                     <h5 class="wow fadeInDown">REGISTRATIONS HAVE BEGUN; SIGN IN WITH YOUR GITHUB ACCOUNTS NOW!</h5>
                     <a style="background-color: grey" class="btn highlight-button-home-white-border margin-four no-margin-bottom wow fadeInUp" href="{{ url_for('auth') }}" target="_blank">Register</a>
+                    -->
+                    <div class="content">
+                      <h2 class="deep-red-text">Registrations Are Over!<br></h2>
+                      <h3 style="color: green">You can work on a project, under the guidance of some mentor :)</h3> 
+                    </div>
                     {% endif %}
                 </div>
             </div>


### PR DESCRIPTION
Replaced `REGISTRATIONS HAVE BEGUN; SIGN IN WITH YOUR GITHUB ACCOUNTS NOW!` with `Registrations Are Over! You can work on a project, under the guidance of some mentor :)` and removed `Register` button.