### PR TITLE
Add script to generate list_of_mentors.json from projects.csv #165

### DIFF
--- a/kwoc/populate_mentor_list.py
+++ b/kwoc/populate_mentor_list.py
@@ -22,6 +22,7 @@ def main():
     with open(MENTORS_JSON, 'w') as f:
         mentors = mentors[1:]
         mentors = list(set(mentors))
+        mentors.sort()
         json.dump(mentors, f)
 
 if __name__ == '__main__':


### PR DESCRIPTION
`list_of_mentors.json` contains mentors and their projects. It's used by a form in `/mid-term`. This PR adds a script to generate the `list_of_mentors.json` from `projects.csv`.