### PR TITLE
Remove share your progress from profile #173

### DIFF
--- a/templates/profile.html
+++ b/templates/profile.html
@@ -122,22 +122,6 @@
                     </div>
 
                     <div class="col2 first">
-                        <h2>Share your Progress</h2>
-                        <div class="grid clearfix">
-                            <a class='social-btn' href="https://www.facebook.com/sharer/sharer.php?u=https://kwoc.kossiitkgp.org/stats/{{ username }}" target= '_blank' style="cursor:pointer;">
-                                <i class="fa fa-facebook"></i>
-                            </a>
-                            <a class='social-btn' href="https://twitter.com/intent/tweet?text=Check out my progress at KWoC &url=https://kwoc.kossiitkgp.org/stats/{{ username }}" target= '_blank'>
-                                <i class="fa fa-twitter"></i>
-                            </a>
-                            <a class='social-btn' href="https://www.linkedin.com/shareArticle?url=https://kwoc.kossiitkgp.org/stats/{{ username }}" target= '_blank'>
-                                <i class="fa fa-linkedin"></i>
-                            </a>
-                                
-                        </div>
-                    </div>
-
-                    <div class="col2 first">
                         <h2>Commits Summary</h2>
                     </div>
                     <br>


### PR DESCRIPTION
Removed  `Share your progess` option from `/stats/<github-handle>`.