### PR TITLE
Send mentor mails

### DIFF
--- a/kwoc/app.py
+++ b/kwoc/app.py
@@ -33,12 +33,6 @@ with open(stats_json, 'r') as f:
     stats_dict = json.load(f)
 # stats_dict = {}
 
-try:
-    open(mid_term_stud,'r')
-except:
-    open(mid_term_stud,'w').close()
-
-
 present_flag=False #This flag ensures, if the id is present or not in stud_json. True refers to id present, and false otherwise
 
 # Separate people with non-zero contributions


### PR DESCRIPTION
The script for sending the mail is in kwoc/sendgrid_mail.py . Make sure to export the env variables of the sendgrid api. And I might have added one too many < br's > in the body of the email. Everything else should be fine.
@themousepotato @Ayushk4 @thealphadollar 